### PR TITLE
Refactor, fix locked joker descriptions

### DIFF
--- a/Main.lua
+++ b/Main.lua
@@ -31,6 +31,58 @@ local function make_atlas(key, path)
 	}
 end
 
+---Replaces the atlas for all `obj_keys` in `smods_obj` with `atlas_key` by calling `take_ownership()`
+---This is roughly equivalent to repeatedly calling:
+---```lua
+---smods_obj:take_ownership(obj_keys[i],
+---  {
+---    atlas = atlas_key
+---  },
+---  silent
+---)
+---```
+---Each obj_key item may be a string, or a key-table entry with additional properties.
+---Example:
+---```lua
+----- atlas.jokers.key refers to an atlas key
+---replace_atlas_for(SMODS.Joker, atlas.jokers.key, {
+---  -- Simple atlas replacement
+---  "blue_joker",
+---  -- Also replaces pos
+---  wee = { pos = { x = 10, y = 1 } },
+---  -- You can also specify an arbitrary string key with ["..."]
+---  ["hologram"] = { soul_pos = { x = 10, y = 10 } },
+---})
+---```
+---@param smods_obj any Needs a valid take_ownership() function
+---@param atlas_key string
+---@param obj_keys table<string, (string|table)> A list of object keys to replace. Each item may be a simple string like in an array, or a key with a table of additional properties to replace.
+---@param silent boolean?
+local function replace_atlas_for(smods_obj, atlas_key, obj_keys, silent)
+	silent = silent or false
+	log.debug(("Replacing atlas for %d objects with \"%s\""):format(#obj_keys, atlas_key))
+	for k, v in pairs(obj_keys) do
+		local obj_key
+		local replace_table
+
+		if type(k) == "number" then
+			-- Assumed to be an array item - the value is the object key
+			obj_key = v
+			replace_table = {}
+		else
+			-- Table item - the key is the object key, the value is a list of additional properties
+			obj_key = k
+			replace_table = v
+		end
+
+		replace_table.atlas = atlas_key
+
+		log.debug("\t" .. obj_key)
+		local orig_o = smods_obj:take_ownership(obj_key, replace_table, silent)
+		log.debug("\tNew object: \n" .. inspectDepth(orig_o, 2, 2))
+	end
+end
+
 ---@enum rankName
 local RANK = {
 	["2"] = "2",
@@ -292,306 +344,50 @@ make_skin(
 --#endregion
 
 --#region ===== Jokers =====
---#region === Common ===
 
-
-SMODS.Joker:take_ownership('blue_joker',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 7, y = 10 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('cavendish',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 5, y = 11 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('green_joker',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 2, y = 11 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('gros_michel',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 7, y = 6 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('ice_cream',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 4, y = 10 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('joker',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 0, y = 0 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('splash',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 6, y = 10 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('riff_raff',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 1, y = 12 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
---#endregion
---#region ==-Uncommon ===
-
-SMODS.Joker:take_ownership('bootstraps',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 9, y = 8 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('ceremonial',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 5, y = 5 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('cloud_9',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 7, y = 12 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('constellation',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 9, y = 10 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('erosion',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 5, y = 13 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('fibonacci',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 1, y = 5 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('hack',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 5, y = 2 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('hologram',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 4, y = 12 },
-		soul_pos = { x = 10, y = 10 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('onyx_agate',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 2, y = 8 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('oops',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 5, y = 6 },
-		soul_pos = { x = 10, y = 3 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('rocket',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 8, y = 12 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('seeing_double',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 4, y = 4 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('smeared',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 4, y = 6 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('sock_and_buskin',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 3, y = 1 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('steel_joker',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 7, y = 2 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('trading',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 9, y = 14 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('vampire',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 2, y = 12 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
---endregion
---region ===Rare===
-
-
-SMODS.Joker:take_ownership('baron',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 6, y = 12 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('baseball',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 6, y = 14 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('campfire',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 5, y = 15 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('obelisk',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 9, y = 12 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('stuntman',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 8, y = 6 },
-		soul_pos = { x = 10, y = 2 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('trio',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 6, y = 4 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Joker:take_ownership('wee',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 10, y = 1 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
+replace_atlas_for(SMODS.Joker, atlas.jokers.key, {
+	--#region === Common ===
+	"blue_joker",
+	"cavendish",
+	"green_joker",
+	"gros_michel",
+	"ice_cream",
+	"joker",
+	"splash",
+	"riff_raff",
+	--#endregion
+	--#region ==-Uncommon ===
+	"bootstraps",
+	"ceremonial",
+	"cloud_9",
+	"constellation",
+	"erosion",
+	"fibonacci",
+	"hack",
+	hologram = { soul_pos = { x = 10, y = 10 } },
+	"onyx_agate",
+	oops = { soul_pos = { x = 10, y = 3 } },
+	"rocket",
+	"seeing_double",
+	"smeared",
+	"sock_and_buskin",
+	"steel_joker",
+	"trading",
+	"vampire",
+	--endregion
+	--region ===Rare===
+	"baron",
+	"baseball",
+	"campfire",
+	"obelisk",
+	stuntman = { soul_pos = { x = 10, y = 2 } },
+	"trio",
+	wee = { pos = { x = 10, y = 1 } },
+	--#endregion
+	--#region =====Legendary=====
+	"caino",
+	--#endregion
+})
 
 -- This removes the glitch effects from Hologram
 ---@type function
@@ -613,21 +409,6 @@ SMODS.DrawStep:take_ownership('floating_sprite',
 	}, true
 )
 
---#endregion
---#region =====Legendary=====
-
-
-SMODS.Joker:take_ownership('caino',
-	{
-		atlas = atlas.jokers.key,
-		pos = { x = 3, y = 8 },
-		soul_pos = { x = 3, y = 9 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
---#endregion
 
 --#region ===== Consumables =====
 

--- a/Main.lua
+++ b/Main.lua
@@ -409,6 +409,7 @@ SMODS.DrawStep:take_ownership('floating_sprite',
 	}, true
 )
 
+--#endregion
 
 --#region ===== Consumables =====
 

--- a/Main.lua
+++ b/Main.lua
@@ -639,17 +639,6 @@ SMODS.Consumable:take_ownership('chariot',
 		atlas = atlas.consumables.key,
 		pos = { x = 7, y = 0 },
 		-- loc_txt in localization file
-		loc_vars = function(self, info_queue, card)
-			info_queue[#info_queue+1] = G.P_CENTERS.m_steel
-			return {
-				vars = {
-					-- Fun fact! the game *specifically* localizes the card name for tarot cards (etc.) so we gotta do it here too!
-					-- localize() is a base-game function from misc_functions
-					localize { type = 'name_text', set = 'Enhanced', key = card.ability.mod_conv },
-					card.ability.max_highlighted
-				}
-			}
-		end,
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -699,9 +688,6 @@ SMODS.Consumable:take_ownership('hanged_man',
 		atlas = atlas.consumables.key,
 		pos = { x = 2, y = 1 },
 		-- loc_txt in localization file
-		loc_vars = function(self, info_queue, card)
-			return { vars = { card.ability.max_highlighted } }
-		end,
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -711,9 +697,6 @@ SMODS.Consumable:take_ownership('high_priestess',
 		atlas = atlas.consumables.key,
 		pos = { x = 2, y = 0 },
 		-- loc_txt in localization file
-		loc_vars = function(self, info_queue, card)
-			return { vars = { card.ability.planets } }
-		end,
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -724,15 +707,6 @@ SMODS.Consumable:take_ownership('tower',
 		atlas = atlas.consumables.key,
 		pos = { x = 6, y = 1 },
 		-- loc_txt in localization file
-		loc_vars = function(self, info_queue, card)
-			info_queue[#info_queue+1] = G.P_CENTERS.m_stone
-			return {
-				vars = {
-					localize { type = 'name_text', set = 'Enhanced', key = card.ability.mod_conv },
-					card.ability.max_highlighted
-				}
-			}
-		end,
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -743,9 +717,6 @@ SMODS.Consumable:take_ownership('immolate',
 		atlas = atlas.consumables.key,
 		pos = { x = 9, y = 4 },
 		-- loc_txt in localization file
-		loc_vars = function(self, info_queue, card)
-			return { vars = { card.ability.extra.destroy, card.ability.extra.dollars } }
-		end,
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -756,9 +727,6 @@ SMODS.Consumable:take_ownership('medium',
 		atlas = atlas.consumables.key,
 		pos = { x = 4, y = 5 },
 		-- loc_txt in localization file
-		loc_vars = function (self, info_queue, card)
-			info_queue[#info_queue+1] = {key = 'purple_seal', set = 'Other'}
-		end
 	},
 	false -- true = silent | suppresses mod badge
 )

--- a/Main.lua
+++ b/Main.lua
@@ -638,14 +638,7 @@ SMODS.Consumable:take_ownership('chariot',
 	{
 		atlas = atlas.consumables.key,
 		pos = { x = 7, y = 0 },
-		loc_txt = {
-			name = "Frank",
-			text = {
-				"Enhances {C:attention}#2#{} selected",
-				"card into a",
-				"{C:attention}#1#",
-			},
-		},
+		-- loc_txt in localization file
 		loc_vars = function(self, info_queue, card)
 			info_queue[#info_queue+1] = G.P_CENTERS.m_steel
 			return {
@@ -713,14 +706,7 @@ SMODS.Consumable:take_ownership('hanged_man',
 	{
 		atlas = atlas.consumables.key,
 		pos = { x = 2, y = 1 },
-		loc_txt = {
-			name = "Varghus",
-			text = {
-				"Destroys up to",
-                "{C:attention}#1#{} selected cards",
-				"{C:black,s:0.9}Lost in black wings"
-			},
-		},
+		-- loc_txt in localization file
 		loc_vars = function(self, info_queue, card)
 			return { vars = { card.ability.max_highlighted } }
 		end,
@@ -732,15 +718,7 @@ SMODS.Consumable:take_ownership('high_priestess',
 	{
 		atlas = atlas.consumables.key,
 		pos = { x = 2, y = 0 },
-		loc_txt = {
-			name = "Echo",
-			text = {
-				"Creates up to {C:attention}#1#",
-				"random {C:planet}Planet{} cards",
-				"{C:inactive}(Must have room)",
-				"{C:blue,s:0.9}Celestial flames"
-			},
-		},
+		-- loc_txt in localization file
 		loc_vars = function(self, info_queue, card)
 			return { vars = { card.ability.planets } }
 		end,
@@ -753,14 +731,7 @@ SMODS.Consumable:take_ownership('tower',
 	{
 		atlas = atlas.consumables.key,
 		pos = { x = 6, y = 1 },
-		loc_txt = {
-			name = "Degyn",
-			text = {
-				"Enhances {C:attention}#2#{} selected",
-				"card into an",
-				"{C:attention}#1#",
-			},
-		},
+		-- loc_txt in localization file
 		loc_vars = function(self, info_queue, card)
 			info_queue[#info_queue+1] = G.P_CENTERS.m_stone
 			return {
@@ -779,15 +750,7 @@ SMODS.Consumable:take_ownership('immolate',
 	{
 		atlas = atlas.consumables.key,
 		pos = { x = 9, y = 4 },
-		loc_txt = {
-			name = "Immolate",
-			text = {
-				"Destroys {C:attention}#1#{} random",
-				"cards in hand,",
-				"gain {C:money}$#2#",
-				"{C:inactive,s:0.9}Dragon insurance pays off"
-			},
-		},
+		-- loc_txt in localization file
 		loc_vars = function(self, info_queue, card)
 			return { vars = { card.ability.extra.destroy, card.ability.extra.dollars } }
 		end,
@@ -800,13 +763,7 @@ SMODS.Consumable:take_ownership('medium',
 	{
 		atlas = atlas.consumables.key,
 		pos = { x = 4, y = 5 },
-		loc_txt = {
-			name = "Void Gift",
-			text = {
-				"One card receives the",
-				"{C:purple}Reaper's Mark{}",
-			},
-		},
+		-- loc_txt in localization file
 		loc_vars = function (self, info_queue, card)
 			info_queue[#info_queue+1] = {key = 'purple_seal', set = 'Other'}
 		end
@@ -819,13 +776,7 @@ SMODS.Consumable:take_ownership('soul',
 		atlas = atlas.consumables.key,
 		pos = { x = 2, y = 2 },
 		-- soul_pos = { x = 6, y = 5 }, -- this would have worked if the game didn't use G.shared_soul for just this one card for some reason
-		loc_txt = {
-			name = "Oh Snap(z)!",
-			text = {
-				"{C:legendary,E:1,s:0.8}A rat!{}",
-				"Creates a {C:legendary}Legendary{} Joker"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -856,15 +807,7 @@ SMODS.Seal:take_ownership('Purple',
 	{
 		atlas = atlas.enhancers.key,
 		pos = { x = 4, y = 4 },
-		loc_txt = {
-			name = "Reaper's Mark",
-			text = {
-				"Creates a {C:tarot}Tarot{} card",
-				"when {C:attention}discarded",
-				"{C:inactive}(Must have room)",
-				"{C:tarot,s:0.9}A gift from the Void",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )

--- a/Main.lua
+++ b/Main.lua
@@ -632,7 +632,6 @@ SMODS.Joker:take_ownership('caino',
 --#region ===== Consumables =====
 
 --#region ===== Tarots =====
---For all consumables, redefine loc_vars and provide base game variables again
 
 SMODS.Consumable:take_ownership('chariot',
 	{
@@ -648,37 +647,6 @@ SMODS.Consumable:take_ownership('fool',
         atlas = atlas.consumables.key,
         pos = { x = 0, y = 0 },
 		-- loc_txt in localization file
-        loc_vars = function(self, info_queue, card)
-            -- Copied from the base game
-            local fool_c = G.GAME.last_tarot_planet and G.P_CENTERS[G.GAME.last_tarot_planet] or nil
-            local last_tarot_planet = fool_c and localize { type = 'name_text', key = fool_c.key, set = fool_c.set } or
-                localize('k_none')
-            local colour = (not fool_c or fool_c.name == 'The Fool') and G.C.RED or G.C.GREEN
-            local main_end = {
-                {
-                    n = G.UIT.C,
-                    config = { align = "bm", padding = 0.02 },
-                    nodes = {
-                        {
-                            n = G.UIT.C,
-                            config = { align = "m", colour = colour, r = 0.05, padding = 0.05 },
-                            nodes = {
-                                { n = G.UIT.T, config = { text = ' ' .. last_tarot_planet .. ' ', colour = G.C.UI.TEXT_LIGHT, scale = 0.3, shadow = true } },
-                            }
-                        }
-                    }
-                }
-            }
-            local loc_vars = { last_tarot_planet }
-            if not (not fool_c or fool_c.name == 'The Fool') then
-                info_queue[#info_queue + 1] = fool_c
-            end
-
-            return {
-                vars = loc_vars,
-                main_end = main_end,
-            }
-        end,
     },
     false -- true = silent | suppresses mod badge
 )
@@ -777,9 +745,6 @@ SMODS.Enhancement:take_ownership('stone',
 		atlas = atlas.enhancers.key,
 		pos = { x = 5, y = 0 },
 		-- loc_txt in localization file
-		loc_vars = function(self, info_queue, card)
-			return { vars = { card.ability.bonus } }
-		end,
 	},
 	false -- true = silent | suppresses mod badge
 )

--- a/Main.lua
+++ b/Main.lua
@@ -643,12 +643,12 @@ SMODS.Consumable:take_ownership('chariot',
 )
 
 SMODS.Consumable:take_ownership('fool',
-    {
-        atlas = atlas.consumables.key,
-        pos = { x = 0, y = 0 },
+	{
+		atlas = atlas.consumables.key,
+		pos = { x = 0, y = 0 },
 		-- loc_txt in localization file
-    },
-    false -- true = silent | suppresses mod badge
+	},
+	false -- true = silent | suppresses mod badge
 )
 
 SMODS.Consumable:take_ownership('hanged_man',

--- a/Main.lua
+++ b/Main.lua
@@ -413,83 +413,20 @@ SMODS.DrawStep:take_ownership('floating_sprite',
 
 --#region ===== Consumables =====
 
---#region ===== Tarots =====
-
-SMODS.Consumable:take_ownership('chariot',
-	{
-		atlas = atlas.consumables.key,
-		pos = { x = 7, y = 0 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Consumable:take_ownership('fool',
-	{
-		atlas = atlas.consumables.key,
-		pos = { x = 0, y = 0 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Consumable:take_ownership('hanged_man',
-	{
-		atlas = atlas.consumables.key,
-		pos = { x = 2, y = 1 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Consumable:take_ownership('high_priestess',
-	{
-		atlas = atlas.consumables.key,
-		pos = { x = 2, y = 0 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-
-SMODS.Consumable:take_ownership('tower',
-	{
-		atlas = atlas.consumables.key,
-		pos = { x = 6, y = 1 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
---#endregion
---#region ===== Spectrals =====
-SMODS.Consumable:take_ownership('immolate',
-	{
-		atlas = atlas.consumables.key,
-		pos = { x = 9, y = 4 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-
-SMODS.Consumable:take_ownership('medium',
-	{
-		atlas = atlas.consumables.key,
-		pos = { x = 4, y = 5 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
-
-SMODS.Consumable:take_ownership('soul',
-	{
-		atlas = atlas.consumables.key,
-		pos = { x = 2, y = 2 },
-		-- soul_pos = { x = 6, y = 5 }, -- this would have worked if the game didn't use G.shared_soul for just this one card for some reason
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
+replace_atlas_for(SMODS.Consumable, atlas.consumables.key, {
+	--#region ===== Tarots =====
+	"chariot",
+	"fool",
+	"hanged_man",
+	"high_priestess",
+	"tower",
+	--#endregion
+	--#region ===== Spectrals =====
+	"immolate",
+	"medium",
+	"soul",
+	--#endregion
+})
 
 -- Override The Soul floating sprite, since it's not actually a floating_sprite for some reason (and so it doesn't use soul_pos)
 -- This needs to be called after our atlases are loaded, hence the event manager
@@ -509,26 +446,15 @@ G.E_MANAGER:add_event(Event({
 }))
 
 --#endregion
---#endregion
 
 --#region ===== Editions/Seals/Extra =====
 
-SMODS.Seal:take_ownership('Purple',
-	{
-		atlas = atlas.enhancers.key,
-		pos = { x = 4, y = 4 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
+replace_atlas_for(SMODS.Seal, atlas.enhancers.key, {
+	"Purple",
+})
 
-SMODS.Enhancement:take_ownership('stone',
-	{
-		atlas = atlas.enhancers.key,
-		pos = { x = 5, y = 0 },
-		-- loc_txt in localization file
-	},
-	false -- true = silent | suppresses mod badge
-)
+replace_atlas_for(SMODS.Enhancement, atlas.enhancers.key, {
+	"stone",
+})
 
 --endregion

--- a/Main.lua
+++ b/Main.lua
@@ -633,16 +633,7 @@ SMODS.Joker:take_ownership('seeing_double',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 4, y = 4 },
-		loc_txt = {
-			name = "Malthy",
-			text = {
-				"{X:mult,C:white} X#1# {} Mult if played",
-                "hand has a scoring",
-                "{C:clubs}Club{} card and a scoring",
-                "card of any other {C:attention}suit",
-				"{C:blue,s:0.8}Different, yet the same"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )

--- a/Main.lua
+++ b/Main.lua
@@ -299,15 +299,7 @@ SMODS.Joker:take_ownership('blue_joker',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 7, y = 10 },
-		loc_txt = {
-			name = "Blue",
-			text = {
-				"{C:chips}+#1#{} Chips for each",
-				"remaining card in {C:attention}deck",
-				"{C:inactive}(Currently {C:chips}+#2#{C:inactive} Chips)",
-				"{C:chips,s:0.9}A noble Sea Slug"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -316,17 +308,7 @@ SMODS.Joker:take_ownership('cavendish',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 5, y = 11 },
-		loc_txt = {
-			name = "Banangry",
-			text = {
-				"{X:mult,C:white} X#1# {} Mult",
-                "{C:green}#2# in #3#{} chance this",
-                "card is destroyed",
-                "at end of round",
-				"{C:mult,s:0.9}Now you've upset him >:c",
-				"{C:attention,s:0.8}Art by FuzzyRemi!",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -335,15 +317,7 @@ SMODS.Joker:take_ownership('green_joker',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 2, y = 11 },
-		loc_txt = {
-			name = "Green Joker",
-			text = {
-				"{C:mult}+#1#{} Mult per hand played",
-                "{C:mult}-#2#{} Mult per discard",
-                "{C:inactive}(Currently {C:mult}+#3#{C:inactive} Mult)",
-				--"{C:blue,s:1.1}discord.gg/RXqc9wxWHs",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -352,17 +326,7 @@ SMODS.Joker:take_ownership('gros_michel',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 7, y = 6 },
-		loc_txt = {
-			name = "Banana",
-			text = {
-				"{C:mult}+#1#{} Mult",
-                "{C:green}#2# in #3#{} chance this",
-                "card is destroyed",
-                "at end of round",
-				"{C:blue,s:0.9}:P",
-				"{C:attention,s:0.8}Art by FuzzyRemi!",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -371,15 +335,7 @@ SMODS.Joker:take_ownership('ice_cream',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 4, y = 10 },
-		loc_txt = {
-			name = "Bedi",
-			text = {
-				"{C:chips}+#1#{} Chips",
-				"{C:chips}-#2#{} Chips for",
-				"every hand played",
-				"{C:green,s:0.9}Yap!"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -388,12 +344,7 @@ SMODS.Joker:take_ownership('joker',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 0, y = 0 },
-		loc_txt = {
-			name = "Jimbo",
-			text = {
-				"{C:red,s:1.1}+#1#{} Mult",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -402,14 +353,7 @@ SMODS.Joker:take_ownership('splash',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 6, y = 10 },
-		loc_txt = {
-			name = "Kink",
-			text = {
-				"Every {C:attention}played card",
-                "counts in scoring",
-				"{C:blue,s:0.9}Big fish!",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -418,15 +362,7 @@ SMODS.Joker:take_ownership('riff_raff',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 1, y = 12 },
-		loc_txt = {
-			name = "Zard",
-			text = {
-				"When {C:attention}Blind{} is selected,",
-                "create {C:attention}#1# {C:blue}Common{C:attention} Jokers",
-                "{C:inactive}(Must have room)",
-				"{C:blue,s:0.9}Lifetime supply of kobolds",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -438,15 +374,7 @@ SMODS.Joker:take_ownership('bootstraps',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 9, y = 8 },
-		loc_txt = {
-			name = "Socks",
-			text = {
-				"{C:mult}+#1#{} Mult for every",
-                "{C:money}$#2#{} you have",
-                "{C:inactive}(Currently {C:mult}+#3#{C:inactive} Mult)",
-				"{C:attention,s:0.8}Pick yourself up by your... socks",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -455,17 +383,7 @@ SMODS.Joker:take_ownership('ceremonial',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 5, y = 5 },
-		loc_txt = {
-			name = "Lagos",
-			text = {
-				"When {C:attention}Blind{} is selected,",
-				"destroy Joker to the right",
-				"and permanently add {C:attention}double",
-				"its sell value to this {C:red}Mult",
-				"{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
-				"{C:purple,s:0.8}Always hungry...",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -474,16 +392,7 @@ SMODS.Joker:take_ownership('cloud_9',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 7, y = 12 },
-		loc_txt = {
-			name = "Stratus",
-			text = {
-				"Earn {C:money}$#1#{} for each",
-                "{C:attention}9{} in your {C:attention}full deck",
-                "at end of round",
-                "{C:inactive}(Currently {C:money}$#2#{}{C:inactive})",
-				"{C:blue,s:0.8}Cozy Cloudbeast",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -492,17 +401,7 @@ SMODS.Joker:take_ownership('constellation',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 9, y = 10 },
-		loc_txt = {
-			name = "Akashi",
-			text = {
-				"This fay gains",
-                "{X:mult,C:white} X#1# {} Mult every time",
-                "a {C:planet}Planet{} card is used",
-                "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
-				"{C:purple,s:0.9}Glittering stars",
-				"{C:red,s:0.8}Art by FuzzyRemi!",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -511,16 +410,7 @@ SMODS.Joker:take_ownership('erosion',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 5, y = 13 },
-		loc_txt = {
-			name = "Valyx",
-			text = {
-				"{C:red}+#1#{} Mult for each",
-                "card below {C:attention}#3#{}",
-                "in your full deck",
-                "{C:inactive}(Currently {C:red}+#2#{C:inactive} Mult)",
-				"{C:chips,s:0.9}The Crocodragon's healing power"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -529,15 +419,7 @@ SMODS.Joker:take_ownership('fibonacci',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 1, y = 5 },
-		loc_txt = {
-			name = "Lorcan",
-			text = {
-				"Each played {C:attention}Ace{},",
-				"{C:attention}2{}, {C:attention}3{}, {C:attention}5{}, or {C:attention}8{} gives",
-				"{C:mult}+#1#{} Mult when scored",
-				"{C:green,s:0.9}Gorp!"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -546,16 +428,8 @@ SMODS.Joker:take_ownership('hack',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 5, y = 2 },
-		loc_txt = {
-			name = "Serkular",
-			text = {
-				"Retrigger",
-                "each played",
-                "{C:attention}2{}, {C:attention}3{}, {C:attention}4{}, or {C:attention}5{}",
-				"{C:red,s:0.8}The best jokes around"
-                },
-			},
-		},
+		-- loc_txt in localization file
+	},
 	false -- true = silent | suppresses mod badge
 )
 
@@ -564,15 +438,7 @@ SMODS.Joker:take_ownership('hologram',
 		atlas = atlas.jokers.key,
 		pos = { x = 4, y = 12 },
 		soul_pos = { x = 10, y = 10 },
-		loc_txt = {
-			name = "Lischer Voge",
-			text = {
-				"This bird gains {X:mult,C:white} X#1# {} Mult",
-				"every time a {C:attention}playing card{}",
-				"is added to your deck",
-				"{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -581,15 +447,7 @@ SMODS.Joker:take_ownership('onyx_agate',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 2, y = 8 },
-		loc_txt = {
-			name = "Rhasakani",
-			text = {
-				"Played cards with",
-                "{C:clubs}Club{} suit give",
-                "{C:mult}+#1#{} Mult when scored",
-				"{C:blue,s:0.9}Shiny~"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -599,15 +457,7 @@ SMODS.Joker:take_ownership('oops',
 		atlas = atlas.jokers.key,
 		pos = { x = 5, y = 6 },
 		soul_pos = { x = 10, y = 3 },
-		loc_txt = {
-			name = "Xenon",
-			text = {
-				"Doubles all {C:attention}listed",
-                "{C:green,E:1,S:1.1}probabilities",
-                "{C:inactive}(ex: {C:green}1 in 3{C:inactive} -> {C:green}2 in 3{C:inactive})",
-				"{C:red,s:0.9}He gave me loaded dice!"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -616,15 +466,7 @@ SMODS.Joker:take_ownership('rocket',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 8, y = 12 },
-		loc_txt = {
-			name = "Einarr",
-			text = {
-				"Earn {C:money}$#1#{} at end of round",
-				"Payout increases by {C:money}$#2#{}",
-				"when {C:attention}Boss Blind{} is defeated",
-				"{C:red,s:0.9}Reach for the stars"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -642,16 +484,7 @@ SMODS.Joker:take_ownership('smeared',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 4, y = 6 },
-		loc_txt = {
-			name = "Smeared Kobold",
-			text = {
-				"{C:hearts}Hearts{} and {C:diamonds}Diamonds",
-				"count as the same suit,",
-				"{C:spades}Spades{} and {C:clubs}Clubs",
-				"count as the same suit",
-				"{C:attention,s:0.8}Art by Boldarts!"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -660,14 +493,7 @@ SMODS.Joker:take_ownership('sock_and_buskin',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 3, y = 1 },
-		loc_txt = {
-			name = "Jaitsu",
-			text = {
-				"Retrigger all",
-				"played {C:attention}face{} cards",
-				"{C:inactive,s:0.9}Jock and Juskin"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -676,17 +502,7 @@ SMODS.Joker:take_ownership('steel_joker',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 7, y = 2 },
-		loc_txt = {
-			name = "Metaflame",
-			text = {
-				"Gives {X:mult,C:white} X#1# {} Mult",
-				"for each {C:attention}Steel Card",
-				"in your {C:attention}full deck",
-				"{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
-				"{C:planet,s:0.9}Beep",
-				"{C:red,s:0.8}Art by LaserFire!",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -695,15 +511,7 @@ SMODS.Joker:take_ownership('trading',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 9, y = 14 },
-		loc_txt = {
-			name = "Kusarii",
-			text = {
-				"If {C:attention}first discard{} of round",
-				"has only {C:attention}1{} card,",
-				"destroy it and earn {C:money}$#1#",
-				"{C:purple,s:0.8}Art by KusariiBites!",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -712,16 +520,7 @@ SMODS.Joker:take_ownership('vampire',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 2, y = 12 },
-		loc_txt = {
-			name = "Ixen",
-			text = {
-				"This Ibex gains {X:mult,C:white} X#1# {} Mult",
-                "per scoring {C:attention}Enhanced card{} played,",
-                "removes card {C:attention}Enhancement",
-                "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
-				"{C:blue,s:0.9}Purifying flame",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -734,15 +533,7 @@ SMODS.Joker:take_ownership('baron',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 6, y = 12 },
-		loc_txt = {
-			name = "Giga",
-			text = {
-				"Each {C:attention}King{}",
-                "held in hand",
-                "gives {X:mult,C:white} X#1# {} Mult",
-				"{C:blue,s:0.9}Submit to the King's icy glare"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -751,14 +542,7 @@ SMODS.Joker:take_ownership('baseball',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 6, y = 14 },
-		loc_txt = {
-			name = "Fletcher",
-			text = {
-				"{C:green}Uncommon{} Jokers",
-                "each give {X:mult,C:white} X#1# {} Mult",
-				"{C:attention,s:0.9}Stylish noodle"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -767,16 +551,7 @@ SMODS.Joker:take_ownership('campfire',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 5, y = 15 },
-		loc_txt = {
-			name = "Apolar",
-			text = {
-				"This Joker gains {X:mult,C:white}X#1#{} Mult",
-				"for each card {C:attention}sold{}, resets",
-				"when {C:attention}Boss Blind{} is defeated",
-				"{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
-				"{C:red,s:0.9}A cozy spot to rest"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -785,17 +560,7 @@ SMODS.Joker:take_ownership('obelisk',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 9, y = 12 },
-		loc_txt = {
-			name = "Borruhn",
-			text = {
-				"This Coga gains {X:mult,C:white} X#1# {} Mult",
-				"per {C:attention}consecutive{} hand played",
-				"without playing your",
-				"most played {C:attention}poker hand",
-				"{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
-				"{C:mult,s:0.7}Tummy :3",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -805,14 +570,7 @@ SMODS.Joker:take_ownership('stuntman',
 		atlas = atlas.jokers.key,
 		pos = { x = 8, y = 6 },
 		soul_pos = { x = 10, y = 2 },
-		loc_txt = {
-			name = "Rider and Ryune",
-			text = {
-				"{C:chips}+#1#{} Chips,",
-                "{C:attention}-#2#{} hand size",
-				"{C:mult,s:0.9}I've got you, little one",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -821,15 +579,7 @@ SMODS.Joker:take_ownership('trio',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 6, y = 4 },
-		loc_txt = {
-			name = "Esker",
-			text = {
-				"{X:mult,C:white} X#1# {} Mult if played",
-				"hand contains",
-				"a {C:attention}#2#",
-				"{C:red,s:0.9}Three eyes grant their power"
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -838,17 +588,7 @@ SMODS.Joker:take_ownership('wee',
 	{
 		atlas = atlas.jokers.key,
 		pos = { x = 10, y = 1 },
-		loc_txt = {
-			name = "Lil Guy",
-			text = {
-				"This lil guy gains",
-				"{C:chips}+#2#{} Chips when each",
-				"played {C:attention}2{} is scored",
-				"{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)",
-				"{C:red,s:0.9}Just a lil guy!",
-				"{C:attention,s:0.8}Art by DaxlMonitor!",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )
@@ -882,15 +622,7 @@ SMODS.Joker:take_ownership('caino',
 		atlas = atlas.jokers.key,
 		pos = { x = 3, y = 8 },
 		soul_pos = { x = 3, y = 9 },
-		loc_txt = {
-			name = "Kornio",
-			text = {
-				"This dragon gains {X:mult,C:white} X#1# {} Mult",
-				"when a {C:attention}face{} card is destroyed",
-				"{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
-				"{C:red,s:0.9}Art by RenTradewind!",
-			},
-		},
+		-- loc_txt in localization file
 	},
 	false -- true = silent | suppresses mod badge
 )

--- a/Main.lua
+++ b/Main.lua
@@ -658,15 +658,7 @@ SMODS.Consumable:take_ownership('fool',
     {
         atlas = atlas.consumables.key,
         pos = { x = 0, y = 0 },
-        loc_txt = {
-            name = "Foolsnapz",
-            text = {
-                "Creates the last",
-                "{C:tarot}Tarot{} or {C:planet}Planet{} card",
-                "used during this run",
-                "{s:0.9,C:tarot}Just one!",
-            },
-        },
+		-- loc_txt in localization file
         loc_vars = function(self, info_queue, card)
             -- Copied from the base game
             local fool_c = G.GAME.last_tarot_planet and G.P_CENTERS[G.GAME.last_tarot_planet] or nil
@@ -816,13 +808,7 @@ SMODS.Enhancement:take_ownership('stone',
 	{
 		atlas = atlas.enhancers.key,
 		pos = { x = 5, y = 0 },
-		loc_txt = {
-			name = "Obscured Card",
-			text = {
-				"{C:chips}+#1#{} Chips",
-                "no rank or suit",
-			},
-		},
+		-- loc_txt in localization file
 		loc_vars = function(self, info_queue, card)
 			return { vars = { card.ability.bonus } }
 		end,

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -312,8 +312,17 @@ return {
                 },
             },
         },
+        Enhanced = {
+            m_stone = {
+                name = "Obscured Card",
+                text = {
+                    "{C:chips}+#1#{} Chips",
+                    "no rank or suit",
+                },
+            }
+        },
         Tarot = {
-            j_chariot = {
+            c_chariot = {
                 name = "Frank",
                 text = {
                     "Enhances {C:attention}#2#{} selected",
@@ -321,7 +330,16 @@ return {
                     "{C:attention}#1#",
                 },
             },
-            j_hanged_man = {
+            c_fool = {
+                name = "Foolsnapz",
+                text = {
+                    "Creates the last",
+                    "{C:tarot}Tarot{} or {C:planet}Planet{} card",
+                    "used during this run",
+                    "{s:0.9,C:tarot}Just one!",
+                },
+            },
+            c_hanged_man = {
                 name = "Varghus",
                 text = {
                     "Destroys up to",
@@ -329,7 +347,7 @@ return {
                     "{C:black,s:0.9}Lost in black wings"
                 },
             },
-            j_high_priestess = {
+            c_high_priestess = {
                 name = "Echo",
                 text = {
                     "Creates up to {C:attention}#1#",
@@ -338,7 +356,7 @@ return {
                     "{C:blue,s:0.9}Celestial flames"
                 },
             },
-            j_tower = {
+            c_tower = {
                 name = "Degyn",
                 text = {
                     "Enhances {C:attention}#2#{} selected",

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -311,6 +311,78 @@ return {
                     "{C:red,s:0.9}Art by RenTradewind!",
                 },
             },
+        },
+        Tarot = {
+            j_chariot = {
+                name = "Frank",
+                text = {
+                    "Enhances {C:attention}#2#{} selected",
+                    "card into a",
+                    "{C:attention}#1#",
+                },
+            },
+            j_hanged_man = {
+                name = "Varghus",
+                text = {
+                    "Destroys up to",
+                    "{C:attention}#1#{} selected cards",
+                    "{C:black,s:0.9}Lost in black wings"
+                },
+            },
+            j_high_priestess = {
+                name = "Echo",
+                text = {
+                    "Creates up to {C:attention}#1#",
+                    "random {C:planet}Planet{} cards",
+                    "{C:inactive}(Must have room)",
+                    "{C:blue,s:0.9}Celestial flames"
+                },
+            },
+            j_tower = {
+                name = "Degyn",
+                text = {
+                    "Enhances {C:attention}#2#{} selected",
+                    "card into an",
+                    "{C:attention}#1#",
+                },
+            },
+        },
+        Spectral = {
+            c_soul = {
+                name = "Oh Snap(z)!",
+                text = {
+                    "{C:legendary,E:1,s:0.8}A rat!{}",
+                    "Creates a {C:legendary}Legendary{} Joker",
+                    "{C:inactive}(Must have room)",
+                },
+            },
+            c_medium = {
+                name = "Void Gift",
+                text = {
+                    "One card receives the",
+                    "{C:purple}Reaper's Mark{}",
+                },
+            },
+            c_immolate = {
+                name = "Immolate",
+                text = {
+                    "Destroys {C:attention}#1#{} random",
+                    "cards in hand,",
+                    "gain {C:money}$#2#",
+                    "{C:inactive,s:0.9}Dragon insurance pays off"
+                },
+            },
+        },
+        Other = {
+            purple_seal = {
+                name = "Reaper's Mark",
+                text = {
+                    "Creates a {C:tarot}Tarot{} card",
+                    "when {C:attention}discarded",
+                    "{C:inactive}(Must have room)",
+                    "{C:tarot,s:0.9}A gift from the Void",
+                },
+            },
         }
     }
 }

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -177,7 +177,6 @@ return {
                     "{C:red,s:0.9}Reach for the stars"
                 },
             },
-
             j_seeing_double = {
                 name = "Malthy",
                 text = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1,0 +1,16 @@
+return {
+    descriptions = {
+        Joker = {
+            j_seeing_double = {
+                name = "Malthy",
+                text = {
+                    "{X:mult,C:white} X#1# {} Mult if played",
+                    "hand has a scoring",
+                    "{C:clubs}Club{} card and a scoring",
+                    "card of any other {C:attention}suit",
+                    "{C:blue,s:0.8}Different, yet the same"
+                },
+            },
+        }
+    }
+}

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -315,7 +315,7 @@ return {
             m_stone = {
                 name = "Obscured Card",
                 text = {
-                    "{C:chips}+#1#{} Chips",
+                    "{C:chips}#1#{} Chips",
                     "no rank or suit",
                 },
             }

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -325,9 +325,9 @@ return {
             c_chariot = {
                 name = "Frank",
                 text = {
-                    "Enhances {C:attention}#2#{} selected",
+                    "Enhances {C:attention}#1#{} selected",
                     "card into a",
-                    "{C:attention}#1#",
+                    "{C:attention}#2#",
                 },
             },
             c_fool = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1,6 +1,183 @@
 return {
     descriptions = {
         Joker = {
+            j_blue_joker = {
+                name = "Blue",
+                text = {
+                    "{C:chips}+#1#{} Chips for each",
+                    "remaining card in {C:attention}deck",
+                    "{C:inactive}(Currently {C:chips}+#2#{C:inactive} Chips)",
+                    "{C:chips,s:0.9}A noble Sea Slug"
+                },
+            },
+            j_cavendish = {
+                name = "Banangry",
+                text = {
+                    "{X:mult,C:white} X#1# {} Mult",
+                    "{C:green}#2# in #3#{} chance this",
+                    "card is destroyed",
+                    "at end of round",
+                    "{C:mult,s:0.9}Now you've upset him >:c",
+                    "{C:attention,s:0.8}Art by FuzzyRemi!",
+                },
+            },
+            j_green_joker = {
+                name = "Green Joker",
+                text = {
+                    "{C:mult}+#1#{} Mult per hand played",
+                    "{C:mult}-#2#{} Mult per discard",
+                    "{C:inactive}(Currently {C:mult}+#3#{C:inactive} Mult)",
+                },
+            },
+            j_gros_michel = {
+                name = "Banana",
+                text = {
+                    "{C:mult}+#1#{} Mult",
+                    "{C:green}#2# in #3#{} chance this",
+                    "card is destroyed",
+                    "at end of round",
+                    "{C:blue,s:0.9}:P",
+                    "{C:attention,s:0.8}Art by FuzzyRemi!",
+                },
+            },
+            j_ice_cream = {
+                name = "Bedi",
+                text = {
+                    "{C:chips}+#1#{} Chips",
+                    "{C:chips}-#2#{} Chips for",
+                    "every hand played",
+                    "{C:green,s:0.9}Yap!"
+                },
+            },
+            j_joker = {
+                name = "Jimbo",
+                text = {
+                    "{C:red,s:1.1}+#1#{} Mult",
+                },
+            },
+            j_splash = {
+                name = "Kink",
+                text = {
+                    "Every {C:attention}played card",
+                    "counts in scoring",
+                    "{C:blue,s:0.9}Big fish!",
+                },
+            },
+            j_riff_raff = {
+                name = "Zard",
+                text = {
+                    "When {C:attention}Blind{} is selected,",
+                    "create {C:attention}#1# {C:blue}Common{C:attention} Jokers",
+                    "{C:inactive}(Must have room)",
+                    "{C:blue,s:0.9}Lifetime supply of kobolds",
+                },
+            },
+            j_bootstraps = {
+                name = "Socks",
+                text = {
+                    "{C:mult}+#1#{} Mult for every",
+                    "{C:money}$#2#{} you have",
+                    "{C:inactive}(Currently {C:mult}+#3#{C:inactive} Mult)",
+                    "{C:attention,s:0.8}Pick yourself up by your... socks",
+                },
+            },
+            j_ceremonial = {
+                name = "Lagos",
+                text = {
+                    "When {C:attention}Blind{} is selected,",
+                    "destroy Joker to the right",
+                    "and permanently add {C:attention}double",
+                    "its sell value to this {C:red}Mult",
+                    "{C:inactive}(Currently {C:mult}+#1#{C:inactive} Mult)",
+                    "{C:purple,s:0.8}Always hungry...",
+                },
+            },
+            j_cloud_9 = {
+                name = "Stratus",
+                text = {
+                    "Earn {C:money}$#1#{} for each",
+                    "{C:attention}9{} in your {C:attention}full deck",
+                    "at end of round",
+                    "{C:inactive}(Currently {C:money}$#2#{}{C:inactive})",
+                    "{C:blue,s:0.8}Cozy Cloudbeast",
+                },
+            },
+            j_constellation = {
+                name = "Akashi",
+                text = {
+                    "This fay gains",
+                    "{X:mult,C:white} X#1# {} Mult every time",
+                    "a {C:planet}Planet{} card is used",
+                    "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
+                    "{C:purple,s:0.9}Glittering stars",
+                    "{C:red,s:0.8}Art by FuzzyRemi!",
+                },
+            },
+            j_erosion = {
+                name = "Valyx",
+                text = {
+                    "{C:red}+#1#{} Mult for each",
+                    "card below {C:attention}#3#{}",
+                    "in your full deck",
+                    "{C:inactive}(Currently {C:red}+#2#{C:inactive} Mult)",
+                    "{C:chips,s:0.9}The Crocodragon's healing power"
+                },
+            },
+            j_fibonacci = {
+                name = "Lorcan",
+                text = {
+                    "Each played {C:attention}Ace{},",
+                    "{C:attention}2{}, {C:attention}3{}, {C:attention}5{}, or {C:attention}8{} gives",
+                    "{C:mult}+#1#{} Mult when scored",
+                    "{C:green,s:0.9}Gorp!"
+                },
+            },
+            j_hack = {
+                name = "Serkular",
+                text = {
+                    "Retrigger",
+                    "each played",
+                    "{C:attention}2{}, {C:attention}3{}, {C:attention}4{}, or {C:attention}5{}",
+                    "{C:red,s:0.8}The best jokes around"
+                },
+            },
+            j_hologram = {
+                name = "Lischer Voge",
+                text = {
+                    "This bird gains {X:mult,C:white} X#1# {} Mult",
+                    "every time a {C:attention}playing card{}",
+                    "is added to your deck",
+                    "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
+                },
+            },
+            j_onyx_agate = {
+                name = "Rhasakani",
+                text = {
+                    "Played cards with",
+                    "{C:clubs}Club{} suit give",
+                    "{C:mult}+#1#{} Mult when scored",
+                    "{C:blue,s:0.9}Shiny~"
+                },
+            },
+            j_oops = {
+                name = "Xenon",
+                text = {
+                    "Doubles all {C:attention}listed",
+                    "{C:green,E:1,S:1.1}probabilities",
+                    "{C:inactive}(ex: {C:green}1 in 3{C:inactive} -> {C:green}2 in 3{C:inactive})",
+                    "{C:red,s:0.9}He gave me loaded dice!"
+                },
+            },
+            j_rocket = {
+                name = "Einarr",
+                text = {
+                    "Earn {C:money}$#1#{} at end of round",
+                    "Payout increases by {C:money}$#2#{}",
+                    "when {C:attention}Boss Blind{} is defeated",
+                    "{C:red,s:0.9}Reach for the stars"
+                },
+            },
+
             j_seeing_double = {
                 name = "Malthy",
                 text = {
@@ -9,6 +186,129 @@ return {
                     "{C:clubs}Club{} card and a scoring",
                     "card of any other {C:attention}suit",
                     "{C:blue,s:0.8}Different, yet the same"
+                },
+            },
+            j_smeared = {
+                name = "Smeared Kobold",
+                text = {
+                    "{C:hearts}Hearts{} and {C:diamonds}Diamonds",
+                    "count as the same suit,",
+                    "{C:spades}Spades{} and {C:clubs}Clubs",
+                    "count as the same suit",
+                    "{C:attention,s:0.8}Art by Boldarts!"
+                },
+            },
+            j_sock_and_buskin = {
+                name = "Jaitsu",
+                text = {
+                    "Retrigger all",
+                    "played {C:attention}face{} cards",
+                    "{C:inactive,s:0.9}Jock and Juskin"
+                },
+            },
+            j_steel_joker = {
+                name = "Metaflame",
+                text = {
+                    "Gives {X:mult,C:white} X#1# {} Mult",
+                    "for each {C:attention}Steel Card",
+                    "in your {C:attention}full deck",
+                    "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
+                    "{C:planet,s:0.9}Beep",
+                    "{C:red,s:0.8}Art by LaserFire!",
+                },
+            },
+            j_trading = {
+                name = "Kusarii",
+                text = {
+                    "If {C:attention}first discard{} of round",
+                    "has only {C:attention}1{} card,",
+                    "destroy it and earn {C:money}$#1#",
+                    "{C:purple,s:0.8}Art by KusariiBites!",
+                },
+            },
+            j_vampire = {
+                name = "Ixen",
+                text = {
+                    "This Ibex gains {X:mult,C:white} X#1# {} Mult",
+                    "per scoring {C:attention}Enhanced card{} played,",
+                    "removes card {C:attention}Enhancement",
+                    "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
+                    "{C:blue,s:0.9}Purifying flame",
+                },
+            },
+            j_baron = {
+                name = "Giga",
+                text = {
+                    "Each {C:attention}King{}",
+                    "held in hand",
+                    "gives {X:mult,C:white} X#1# {} Mult",
+                    "{C:blue,s:0.9}Submit to the King's icy glare"
+                },
+            },
+            j_baseball = {
+                name = "Fletcher",
+                text = {
+                    "{C:green}Uncommon{} Jokers",
+                    "each give {X:mult,C:white} X#1# {} Mult",
+                    "{C:attention,s:0.9}Stylish noodle"
+                },
+            },
+            j_campfire = {
+                name = "Apolar",
+                text = {
+                    "This Joker gains {X:mult,C:white}X#1#{} Mult",
+                    "for each card {C:attention}sold{}, resets",
+                    "when {C:attention}Boss Blind{} is defeated",
+                    "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
+                    "{C:red,s:0.9}A cozy spot to rest"
+                },
+            },
+            j_obelisk = {
+                name = "Borruhn",
+                text = {
+                    "This Coga gains {X:mult,C:white} X#1# {} Mult",
+                    "per {C:attention}consecutive{} hand played",
+                    "without playing your",
+                    "most played {C:attention}poker hand",
+                    "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
+                    "{C:mult,s:0.7}Tummy :3",
+                },
+            },
+            j_stuntman = {
+                name = "Rider and Ryune",
+                text = {
+                    "{C:chips}+#1#{} Chips,",
+                    "{C:attention}-#2#{} hand size",
+                    "{C:mult,s:0.9}I've got you, little one",
+                },
+            },
+            j_trio = {
+                name = "Esker",
+                text = {
+                    "{X:mult,C:white} X#1# {} Mult if played",
+                    "hand contains",
+                    "a {C:attention}#2#",
+                    "{C:red,s:0.9}Three eyes grant their power"
+                },
+            },
+            j_wee = {
+                name = "Lil Guy",
+                text = {
+                    "This lil guy gains",
+                    "{C:chips}+#2#{} Chips when each",
+                    "played {C:attention}2{} is scored",
+                    "{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)",
+                    "{C:red,s:0.9}Just a lil guy!",
+                    "{C:attention,s:0.8}Art by DaxlMonitor!",
+                },
+            },
+            j_caino = {
+                name = "Kornio",
+                text = {
+                    "This dragon gains {X:mult,C:white} X#1# {} Mult",
+                    "when a {C:attention}face{} card is destroyed",
+                    "{C:inactive}(Currently {X:mult,C:white} X#2# {C:inactive} Mult)",
+                    "{C:red,s:0.9}Art by RenTradewind!",
                 },
             },
         }


### PR DESCRIPTION
Moves all descriptions into a proper localization file, and significantly deduplicates code via the new `replace_atlas_for` function.